### PR TITLE
feat: validate service name before profiler creation

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -27,6 +27,7 @@ import {Profiler} from './profiler';
 import * as heapProfiler from './profilers/heap-profiler';
 
 const pjson = require('../../package.json');
+const serviceRegex = /^[a-z]([-a-z0-9_.]{0,253}[a-z0-9])?$/;
 
 /**
  * @return value of metadata field.
@@ -84,7 +85,14 @@ function initConfigLocal(config: Config): ProfilerConfig {
       extend(true, {}, defaultConfig, envSetConfig, envConfig, config);
 
   if (!hasService(mergedConfig)) {
-    throw new Error('Service must be specified in the configuration.');
+    throw new Error('Service must be specified in the configuration');
+  }
+
+  if (!serviceRegex.test(mergedConfig.serviceContext.service)) {
+    throw new Error(`Service ${
+        mergedConfig.serviceContext
+            .service} does not match regular expression "${
+        serviceRegex.toString()}"`);
   }
 
   return mergedConfig;

--- a/ts/test/fixtures/test-config.json
+++ b/ts/test/fixtures/test-config.json
@@ -1,12 +1,12 @@
 {
   "logLevel": 3,
   "serviceContext": {
-    "version": "envConfig-version",
-    "service": "envConfig-service"
+    "version": "env_config_version",
+    "service": "env_config_service"
   },
   "disableHeap": true,
   "disableTime": true,
-  "instance": "envConfig-instance",
-  "zone": "envConfig-zone",
-  "projectId": "envConfig-fake-projectId"
+  "instance": "env_config_instance",
+  "zone": "env_config_zone",
+  "projectId": "env_config_fake-projectId"
 }


### PR DESCRIPTION
fixes #309 

Without this fix, profiler continue to try to create profiles, logging failures to create the profile at the "warn" level.