### PR TITLE
chore: stop using methods with deprecation warnings in node 10.12.0

### DIFF
--- a/bindings/sampling-heap-profiler.cc
+++ b/bindings/sampling-heap-profiler.cc
@@ -62,7 +62,7 @@ NAN_METHOD(StartSamplingHeapProfiler) {
       return Nan::ThrowTypeError("First argument type must be Integer.");
     }
 
-#if NODE_MODULE_VERSION > NODE_10_0_MODULE_VERSION
+#if NODE_MODULE_VERSION > NODE_8_0_MODULE_VERSION
     uint64_t sample_interval = info[0].As<Integer>()->Value();
     int stack_depth = info[1].As<Integer>()->Value();
 #else

--- a/bindings/time-profiler.cc
+++ b/bindings/time-profiler.cc
@@ -83,7 +83,7 @@ NAN_METHOD(StopProfiling) {
 }
 
 NAN_METHOD(SetSamplingInterval) {
-#if NODE_MODULE_VERSION > NODE_10_0_MODULE_VERSION
+#if NODE_MODULE_VERSION > NODE_8_0_MODULE_VERSION
   int us = info[0].As<Integer>()->Value();
 #else
   int us = info[0].As<Integer>()->IntegerValue();


### PR DESCRIPTION
I confirmed that this still builds with Node 10.0.0.

Part of fixing #315 