### PR TITLE
Add samples with snippets for documentation

### DIFF
--- a/samples/app.js
+++ b/samples/app.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// [START profiler_setup_nodejs_app_engine]
+require('@google-cloud/profiler').start();
+// [END profiler_setup_nodejs_app_engine]

--- a/samples/snippets.js
+++ b/samples/snippets.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// [START profiler_setup_nodejs_compute_engine]
+require('@google-cloud/profiler').start({
+  serviceContext: {
+      service: 'your-service',
+      version: '1.0.0'
+  }
+});
+// [END profiler_setup_nodejs_compute_engine]


### PR DESCRIPTION
The documentation on https://cloud.google.com/profiler/docs/profiling-nodejs
should come from code snippets on GitHub rather than be hard coded.

We show JS snippets, so I can't use the TS sources.