### PR TITLE
Revert "chore: remove redirect of nvm install in e2e test to make fai…

### DIFF
--- a/testing/integration_test.go
+++ b/testing/integration_test.go
@@ -79,11 +79,9 @@ retry curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.
 export NVM_DIR="$HOME/.nvm" >/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" >/dev/null
 
-# nvm install writes to stderr and stdout on successful install, so some
-# output will appear on successful installs. To reduce the amount of output, 
-# while maintaining error messages printed when nvm install fails, output to
-# stdout is redirected to /dev/null.
-{{if .NVMMirror}}NVM_NODEJS_ORG_MIRROR={{.NVMMirror}}{{end}} retry nvm install {{.NodeVersion}} >/dev/null
+# nvm install writes to stderr and stdout on successful install, so both are
+# redirected.
+{{if .NVMMirror}}NVM_NODEJS_ORG_MIRROR={{.NVMMirror}}{{end}} retry nvm install {{.NodeVersion}} &>/dev/null
 npm -v
 node -v
 NODEDIR=$(dirname $(dirname $(which node)))


### PR DESCRIPTION
…lures easier to triage (#320)"

This reverts commit 2f2630408bac9a67792aa49abd3162eacb99329f, which made the e2e test output too verbose to be easy to look through.