### PR TITLE
chore: rename node-pre-gyp module

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "profiler",
+      "target_name": "google_cloud_profiler",
       "sources": [ 
         "bindings/profiler.cc",
       ],

--- a/bindings/profiler.cc
+++ b/bindings/profiler.cc
@@ -186,4 +186,4 @@ NAN_MODULE_INIT(InitAll) {
   target->Set(Nan::New<String>("heapProfiler").ToLocalChecked(), heapProfiler);
 }
 
-NODE_MODULE(profiler, InitAll);
+NODE_MODULE(google_cloud_profiler, InitAll);

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "node": ">=6.12.3 <8.0.0 || >=8.9.4 <10.0.0 || >=10.4.1"
   },
   "binary": {
-    "module_name": "profiler",
+    "module_name": "google_cloud_profiler",
     "module_path": "./build/{node_abi}-{platform}-{arch}-{libc}",
     "host": "https://storage.googleapis.com/cloud-profiler-e2e/cprof-e2e-artifacts/nodejs/release",
     "package_name": "{node_abi}-{platform}-{arch}-{libc}.tar.gz"


### PR DESCRIPTION
Module name is used in node-pre-gyp's flags. This name should be more unique.