### PR TITLE
chore: remove synth.py

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -1,8 +1,0 @@
-import synthtool as s
-import synthtool.gcp as gcp
-import logging
-
-common_templates = gcp.CommonTemplates()
-logging.basicConfig(level=logging.DEBUG)
-templates = common_templates.node_library()
-s.copy(templates / ".kokoro")


### PR DESCRIPTION
Stop autosynth from trying to update templates on this repository as we wait for pre-built binaries publishing.