### PR TITLE
fix: use NAN from github to fix v8 canary e2e test

### DIFF
--- a/testing/integration_test.go
+++ b/testing/integration_test.go
@@ -93,6 +93,13 @@ retry git fetch origin {{if .PR}}pull/{{.PR}}/head{{else}}{{.Branch}}{{end}}:pul
 git checkout pull_branch
 git reset --hard {{.Commit}}
 retry npm install --nodedir="$NODEDIR" >/dev/null
+
+# TODO: remove this workaround.
+# For v8-canary tests, we need to use the version of NAN on github, which 
+# contains unreleased fixes which allows the native component to be compiled
+# with Node 11.
+{{if .NVMMirror}} retry npm install https://github.com/nodejs/nan.git {{end}}
+
 npm run compile 
 npm pack --nodedir="$NODEDIR" >/dev/null
 VERSION=$(node -e "console.log(require('./package.json').version);")


### PR DESCRIPTION
Log for v8 canary test run with this change: https://sponge.corp.google.com/target?id=579e6989-4c99-43fd-b719-58442c00cbf7&target=cloud-profiler%2Fnodejs-agent%2Fpresubmit&searchFor=