### PR TITLE
fix: scanner.ts should recursively search .git and node_modules directories

### DIFF
--- a/ts/third_party/cloud-debug-nodejs/README.google
+++ b/ts/third_party/cloud-debug-nodejs/README.google
@@ -8,7 +8,8 @@ Description:
        that lets you debug your applications in production without stopping or
        pausing your application.
 Local Modifications:
-       All code except scanner.ts has been removed.
+       All code except scanner.ts has been removed. scanner.ts has been modified
+       so that node_modules directory will be searched when using scanner.ts.
 
        Imported as a git-subtree.
 

--- a/ts/third_party/cloud-debug-nodejs/src/agent/io/scanner.ts
+++ b/ts/third_party/cloud-debug-nodejs/src/agent/io/scanner.ts
@@ -194,7 +194,7 @@ function findFiles(baseDir: string, regex: RegExp): Promise<string[]> {
 
     find.on('directory', (dir: string, ignore: fs.Stats, stop: () => void) => {
       const base = path.basename(dir);
-      if (base === '.git' || base === 'node_modules') {
+      if (base === '.git') {
         stop();  // do not descend
       }
     });


### PR DESCRIPTION
We want modules to also have source map support.