### PR TITLE
fix: fix continuous e2e test

### DIFF
--- a/tools/linux_build_and_test.sh
+++ b/tools/linux_build_and_test.sh
@@ -20,7 +20,7 @@ set -e pipefail
 set -x
 
 case $KOKORO_JOB_TYPE in
-  CONTINUOUS_GITHUB)
+  CONTINUOUS_INTEGRATION)
     BUILD_TYPE=continuous
     ;;
   PRESUBMIT_GITHUB)


### PR DESCRIPTION
For our continuous e2e tests, the value of $KOKORO_JOB_TYP is CONTINUOUS_INTEGRATION not CONTINUOUS_GITHUB.

This change should fix continuous e2e tests which were broken with #357.