### PR TITLE
chore: add copy of kokoro configs to tools/kokoro

### DIFF
--- a/tools/kokoro/common.cfg
+++ b/tools/kokoro/common.cfg
@@ -1,0 +1,22 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 72935
+      keyname: "cloud-profiler-e2e-service-account-key"
+    }
+  }
+}

--- a/tools/kokoro/continuous-v8-canary.cfg
+++ b/tools/kokoro/continuous-v8-canary.cfg
@@ -1,0 +1,21 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Location of the build script in this repository.
+build_file: "cloud-profiler-nodejs/testing/integration_test.sh"
+
+env_vars {
+  key: "RUN_ONLY_V8_CANARY_TEST"
+  value: "true"
+}

--- a/tools/kokoro/continuous.cfg
+++ b/tools/kokoro/continuous.cfg
@@ -1,0 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Location of the build script in this repository.
+build_file: "cloud-profiler-nodejs/tools/linux_build_and_test.sh"

--- a/tools/kokoro/presubmit.cfg
+++ b/tools/kokoro/presubmit.cfg
@@ -1,0 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Location of the build script in this repository.
+build_file: "cloud-profiler-nodejs/tools/linux_build_and_test.sh"


### PR DESCRIPTION
I'm going to add a kokoro release build. I'd like to have this config placed in the same directory as other configs. So, since it will be less clear if we have the release config in the "testing" directory, I plan to move all configs to the "tools" directory.

After this PR is merged, I will change the directory which internal configs point to. Then I will delete the configs in the original location.