### PR TITLE
chore: copy continuous and presubmit kokoro configs into separate directories

### DIFF
--- a/tools/kokoro/continuous/continuous-v8-canary.cfg
+++ b/tools/kokoro/continuous/continuous-v8-canary.cfg
@@ -1,0 +1,21 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Location of the build script in this repository.
+build_file: "cloud-profiler-nodejs/testing/integration_test.sh"
+
+env_vars {
+  key: "RUN_ONLY_V8_CANARY_TEST"
+  value: "true"
+}

--- a/tools/kokoro/continuous/continuous.cfg
+++ b/tools/kokoro/continuous/continuous.cfg
@@ -1,0 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Location of the build script in this repository.
+build_file: "cloud-profiler-nodejs/tools/linux_build_and_test.sh"

--- a/tools/kokoro/presubmit/presubmit.cfg
+++ b/tools/kokoro/presubmit/presubmit.cfg
@@ -1,0 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Location of the build script in this repository.
+build_file: "cloud-profiler-nodejs/tools/linux_build_and_test.sh"


### PR DESCRIPTION
This is the first step to moving the presubmit and continuous configs into their own directories.