### PR TITLE
fix: correct errors in kokoro release

### DIFF
--- a/tools/kokoro/release/publish-npm.cfg
+++ b/tools/kokoro/release/publish-npm.cfg
@@ -23,19 +23,4 @@ before_action {
   }
 }
 
-# Download trampoline resources.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
-
-# Use the trampoline script to run in docker.
-build_file: "cloud-profiler-nodejs/.kokoro/trampoline.sh"
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:8-user"
-}
-
-env_vars: {
-    key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/cloud-debug-nodejs/.kokoro/publish.sh"
-}
+build_file: "cloud-profiler-nodejs/tools/publish.sh"

--- a/tools/linux_build_and_test.sh
+++ b/tools/linux_build_and_test.sh
@@ -54,6 +54,6 @@ gsutil cp -r "${BASE_DIR}/artifacts/." "gs://${GCS_LOCATION}/"
 export BINARY_HOST="https://storage.googleapis.com/${GCS_LOCATION}"
 "${BASE_DIR}/testing/integration_test.sh"
 
-if [ "$BUILD_TYPE" -eq "release" ]; then
+if [ "$BUILD_TYPE" == "release" ]; then
   gsutil cp -r "${BASE_DIR}/artifacts/." "gs://cloud-profiler/nodejs/release"
 fi


### PR DESCRIPTION
In experimenting with the kokoro release, I found I that there are some errors in current kokoro configs and scripts used.

Right now, we want to call the publish script directly (rather than use devrel's trampoline.sh, which we aren't currently set up to do anyways). Also the release workflow did not copy binaries to "gs://cloud-profiler/nodejs/release".