### PR TITLE
fix: update name of key to publish to npm

### DIFF
--- a/tools/kokoro/release/publish-npm.cfg
+++ b/tools/kokoro/release/publish-npm.cfg
@@ -17,7 +17,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 73713
-      keyname: "google_cloud_npm_token"
+      keyname: "google-cloud-profiler-npm-token"
       backend_type: FASTCONFIGPUSH
     }
   }


### PR DESCRIPTION
The keys to publish to npm have been updated to transition to per-project keys. 

We need to update he name of the key we used.