### PR TITLE
chore: don't install gcp-releasetool in publish script

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -18,10 +18,6 @@ set -eo pipefail
 
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-# Start the releasetool reporter
-python3 -m pip install gcp-releasetool
-python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
-
 cd $(dirname $0)/..
 
 NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_google_cloud_npm_token)


### PR DESCRIPTION
We are not yet using gcp-releasetool, and currently get the following error when trying to install this with pip: 
```
Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/usr/local/lib/python3.4/dist-packages/releasetool'
```
We should remove these steps (at least until we unify our release process with the release process for other Google Client Library node modules).

Part of #47