### PR TITLE
fix: update npm token used in publish script

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -24,7 +24,7 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 
 cd $(dirname $0)/..
 
-NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_google_cloud_npm_token)
+NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_google-cloud-profiler-npm-token)
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 npm install


### PR DESCRIPTION
In #417, I updated the the npm token fetched from keystore. I did not update the name of the token in the publish script.

This is part of #47.