### PR TITLE
v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/profiler",
-  "version": "1.0.1-alpha.0",
+  "version": "1.0.1",
   "description": "Adds support for Stackdriver Profiler to Node.js applications",
   "repository": "googleapis/cloud-profiler-nodejs",
   "main": "out/src/index.js",


### PR DESCRIPTION
Release Notes:
https://github.com/googleapis/cloud-profiler-nodejs/releases/edit/untagged-6808b8a4e83df6592cbd

This will be the final release before adding pre-compiled binaries (initially just for non-Alpine linux).

I accidentally publish a version with the "latest" tag and a precompiled binary when testing workflows. But I think I'd like to bump the minor version when we add a new pre-compiled binary. So, this release will make the latest release no have associated pre-compiled binaries.