### PR TITLE
chore: silence deprecation warnings that appear with gcc 8

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,8 @@
       "sources": [ 
         "bindings/profiler.cc",
       ],
-      "include_dirs": [ "<!(node -e \"require('nan')\")" ]
+      "include_dirs": [ "<!(node -e \"require('nan')\")" ],
+      "cflags": [ "-Wno-cast-function-type" ]
     },
     {
       "target_name": "action_after_build",


### PR DESCRIPTION
https://github.com/nodejs/nan/issues/807#issuecomment-455750192 recommends using the "-Wno-cast-function-type" to silence deprecations warnings that appear with GCC 8.

Silences warnings users see in #315.