### PR TITLE
fix: fix testing bash script so code coverage reported

### DIFF
--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -39,7 +39,7 @@ WINDOWS="false"
     ;;
   esac
 
-if [ "$WINDOWS" -ne "true" ]; then
+if [ "$WINDOWS" != "true" ]; then
   bash $KOKORO_GFILE_DIR/codecov.sh  
 fi
 


### PR DESCRIPTION
Currently, code coverage is not run. This is the error we see:
```
+ '[' false -ne true ']'
github/cloud-profiler-nodejs/.kokoro/test.sh: line 42: [: false: integer expression expected
```