### PR TITLE
fix: use latest version of nan when installing pprof-nodejs in v8-canary test

### DIFF
--- a/testing/integration_test.go
+++ b/testing/integration_test.go
@@ -94,13 +94,13 @@ retry git fetch origin {{if .PR}}pull/{{.PR}}/head{{else}}{{.Branch}}{{end}}:pul
 git checkout pull_branch
 git reset --hard {{.Commit}}
 
-retry npm install --nodedir="$NODEDIR" >/dev/null
-
 # TODO: remove this workaround.
 # For v8-canary tests, we need to use the version of NAN on github, which 
 # contains unreleased fixes which allows the native component to be compiled
 # with Node 11.
 {{if .NVMMirror}} retry npm install https://github.com/nodejs/nan.git {{end}}
+
+retry npm install --nodedir="$NODEDIR" >/dev/null
 
 npm run compile 
 npm pack --nodedir="$NODEDIR" >/dev/null


### PR DESCRIPTION
This allows v8-canary e2e tests to pass. 

Example: https://sponge.corp.google.com/target?id=364d9f26-a6a0-41d4-b75b-cec020b84abc&target=cloud-profiler%2Fnodejs-agent%2Fcontinuous%2Fcontinuous-v8-canary&searchFor=