### PR TITLE
DO NOT REVIEW, fix: move @type dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@google-cloud/common": "^0.31.0",
-    "@types/console-log-level": "^1.4.0",
-    "@types/semver": "^5.5.0",
     "bindings": "^1.2.1",
     "console-log-level": "^1.4.0",
     "delay": "^4.0.1",
@@ -52,6 +50,7 @@
     "teeny-request": "^3.3.0"
   },
   "devDependencies": {
+    "@types/console-log-level": "^1.4.0",
     "@types/extend": "^3.0.0",
     "@types/lodash.pickby": "^4.6.4",
     "@types/long": "^4.0.0",
@@ -62,6 +61,7 @@
     "@types/pify": "^3.0.0",
     "@types/pretty-ms": "^4.0.0",
     "@types/request": "^2.47.1",
+    "@types/semver": "^5.5.0",
     "@types/sinon": "^7.0.3",
     "@types/tmp": "0.0.34",
     "codecov": "^3.0.0",


### PR DESCRIPTION
Fixes #435 

Currently just running e2e test to see if these type definitions are needed or not.