### PR TITLE
fix: profiler should still start when source mapper can't be initialized

### DIFF
--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -331,8 +331,9 @@ export class Profiler extends ServiceObject {
             await SourceMapper.create(this.config.sourceMapSearchPath);
       } catch (err) {
         this.logger.error(
-            `Failed to initialize source maps and start profiler: ${err}`);
-        return;
+            `Failed to initialize SourceMapper. Source map support has been disabled: ${
+                err}`);
+        this.config.disableSourceMaps = true;
       }
     }
     this.runLoop();


### PR DESCRIPTION
When running a benchmark in docker, Jianqiao saw this error:
```
@google-cloud/profiler Failed to initialize source maps and start profiler: Error: failed to get source maps from /: Error: ENOENT: no such file or directory, lstat 
```

Lazy source map loading will likely change this, but as a work-around for now, I don't think failure to initialize the SourceMapper should disabled the profiler.