### PR TITLE
chore: Revert "fix: temporarily don't npmaudit check to pass before release"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ workflows:
             - node10
             - node11
             - gocheck
+            - npmaudit
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Reverts googleapis/cloud-profiler-nodejs#446