### PR TITLE
v1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/profiler",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Adds support for Stackdriver Profiler to Node.js applications",
   "repository": "googleapis/cloud-profiler-nodejs",
   "main": "out/src/index.js",


### PR DESCRIPTION
Draft of release notes:
https://github.com/googleapis/cloud-profiler-nodejs/releases/edit/untagged-a34c6b19586a30f46bfb

I need to bump the version before I switch to "releasetool", which cannot parse the tag "v1.1.0-1". 