### PR TITLE
build: drop support for Node 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node6:
-           filters: *release_tags
       - node8:
            filters: *release_tags
       - node10:
@@ -63,7 +61,6 @@ workflows:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node6
             - node8
             - node10
             - node11
@@ -75,11 +72,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node6:
-    docker:
-      - image: node:6
-        user: node
-    <<: *unit_tests
   node8:
     docker:
       - image: node:8

--- a/.kokoro/continuous/node6/common.cfg
+++ b/.kokoro/continuous/node6/common.cfg
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/cloud-profiler-nodejs/.kokoro/test.sh"
+    value: "github/cloud-profiler-nodejs/.kokoro/not-supported.sh"
 }

--- a/.kokoro/not-supported.sh
+++ b/.kokoro/not-supported.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# TODO(nolanmar): Remove all kokoro configs for Node 6 tests, and then remove 
+# this file.
+echo "SKIPPING TESTS: Node 6 is no longer supported"

--- a/system-test/integration_test.go
+++ b/system-test/integration_test.go
@@ -211,17 +211,6 @@ func TestAgentIntegration(t *testing.T) {
 			InstanceConfig: proftest.InstanceConfig{
 				ProjectID:   projectID,
 				Zone:        zone,
-				Name:        fmt.Sprintf("profiler-test-node6-%s", runID),
-				MachineType: "n1-standard-1",
-			},
-			name:         fmt.Sprintf("profiler-test-node6-%s-gce", runID),
-			wantProfiles: wantProfiles,
-			nodeVersion:  "6",
-		},
-		{
-			InstanceConfig: proftest.InstanceConfig{
-				ProjectID:   projectID,
-				Zone:        zone,
 				Name:        fmt.Sprintf("profiler-test-node8-%s", runID),
 				MachineType: "n1-standard-1",
 			},


### PR DESCRIPTION
I do have a "TODO" in this change. 
I plan to complete all work for dropping Node 6 support by EOD, and plan to release the agent on Monday.