### PR TITLE
chore: log the agent's version on start-up

### DIFF
--- a/ts/src/profiler.ts
+++ b/ts/src/profiler.ts
@@ -368,6 +368,7 @@ export class Profiler extends ServiceObject {
         this.config.disableSourceMaps = true;
       }
     }
+    this.logger.debug(`Profiling agent v${pjson.version} is initialized`);
     this.runLoop();
   }
 


### PR DESCRIPTION
Note that the version of the agent will only be logged if the configuration is successfully initialized, and the "start()" method of the Profiler class is called.