### PR TITLE
Revert "chore(deps): update dependency nock to v11"

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jsdoc-fresh": "^1.0.1",
     "linkinator": "^1.5.0",
     "mocha": "^6.1.4",
-    "nock": "^11.0.0",
+    "nock": "^10.0.0",
     "nyc": "^14.1.0",
     "sinon": "^7.3.2",
     "source-map-support": "^0.5.6",


### PR DESCRIPTION
Reverts googleapis/cloud-profiler-nodejs#534

Our E2E tests started failing with compilation errors; I think it's related to this change.