### PR TITLE
chore(deps): pin pprof 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "extend": "^3.0.2",
     "gcp-metadata": "^2.0.0",
     "parse-duration": "^0.1.1",
-    "pprof": "^1.0.0",
+    "pprof": "1.1.0",
     "pretty-ms": "^5.0.0",
     "protobufjs": "~6.8.6",
     "semver": "^6.0.0",


### PR DESCRIPTION
`@google-cloud/profiler` depends heavily on the `pprof` module. 

We want to be sure that changes to `pprof` that introduce bugs or problems in `@google-cloud/profiler` can be caught by `@google-cloud/profiler`'s  presubmit tests, rather than immediately impacting `@google-cloud/profiler` as its running in prod. 

This will allow us to concentrate testing in this repository, rather than duplicate all testing here and in https://github.com/google/pprof-nodejs.