### PR TITLE
build: allow profiler to have custom actions

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -7,4 +7,4 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
-s.copy(templates)
+s.copy(templates, excludes=[".github/workflows/ci.yaml"])


### PR DESCRIPTION
we shouldn't overwrite `.github/workflows/ci.yaml` with the template version, since `cloud-profiler-nodejs` has custom checks.

see: https://github.com/googleapis/cloud-profiler-nodejs/pull/631