### PR TITLE
chore: compile then run golang test in e2e test

### DIFF
--- a/system-test/integration_test.sh
+++ b/system-test/integration_test.sh
@@ -31,11 +31,11 @@ cd "system-test"
 # dependencies breaking this test.
 go version
 go mod init e2e
-retry go get -t -d -tags=integration .
+retry go test -c -tags=integration .
 
 if [ "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" = "" ]; then
-  go test -timeout=30m -tags=integration -run TestAgentIntegration -commit="$COMMIT" -branch="$BRANCH" -repo="$REPO"
+  ./e2e.test -commit="$COMMIT" -branch="$BRANCH" -repo="$REPO"
 else
-  go test -timeout=30m -tags=integration -run TestAgentIntegration -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
+  ./e2e.test -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
 fi
 


### PR DESCRIPTION
This allows the installation of dependencies for golang test to be retried.
