### PR TITLE
fix: malformed tsconfig causing broken tests #640

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
   "include": [
     "src/*.ts",
     "test/*.ts",
-    "system-test/*.ts",
-  ],
+    "system-test/*.ts"
+  ]
 }


### PR DESCRIPTION
#640 introduces automatic `gts clean` on `precompile`. `gts` depends on `tsconfig.json`, which is currently malformed due to trailing `,`. This PR fixes this problem and will allow builds from #640 to finish.